### PR TITLE
CCD-1862: Resolve CVE-2021-28170

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,6 +292,9 @@ dependencies {
 
   implementation group: 'net.minidev', name: 'json-smart', version: '2.4.7'
 
+  // Explicitly specify version of jakarta.el to be used to resolve CVE-2021-28170
+  implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'
+
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
   implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    
-    <suppress until="2021-08-25">
-		<notes>In the Jakarta Expression Language implementation 3.0.3 and earlier, 
-		a bug in the ELParserTokenManager enables invalid EL expressions to be evaluated as if they were valid.
-		</notes>
-		<cve>CVE-2021-28170</cve>
-	</suppress>
-    
+
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1862 (https://tools.hmcts.net/jira/browse/CCD-1862)


### Change description ###
Changed build.gradle to explicitly specify version of jakarta.el to use.
This will resolve CVE-2021-28170.

Removed CVE-2021-28170 entry from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
