### PR TITLE
CCD-2144: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ def versions = [
   jetty           : '9.4.43.v20210629'
 ]
 
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 
 // before committing a change, make sure task still works
 dependencyUpdates {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,9 +7,4 @@
     <cve>CVE-2021-37137</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Temp suppression to unblock pipeline.</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2144 (https://tools.hmcts.net/jira/browse/CCD-2144)


### Change description ###
- Updated build.gradle.  Added override of spring-framework.version property with value set to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
