### PR TITLE
CCD-2378: Re-enable Fortify scan

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,11 +12,10 @@ def product = "hmc"
 def component = "spring-boot-template"
 
 withNightlyPipeline(type, product, component) {
-  // Temporarily disable fortify scan stage until 'entitlementPreferenceType is not available' issue is fixed
-  //enableFortifyScan('hmc-aat')
-  //after('fortify-scan') {
-  //  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
-  //}
+  enableFortifyScan('hmc-aat')
+  after('fortify-scan') {
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
+  }
 }
 
 // env variables needed for BEFTA.

--- a/build.gradle
+++ b/build.gradle
@@ -377,4 +377,5 @@ task fortifyScan(type: JavaExec)  {
   main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
+  ignoreExitValue = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -377,5 +377,6 @@ task fortifyScan(type: JavaExec)  {
   main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
-  ignoreExitValue = true
+  // Uncomment the line below to prevent the build from failing if the Fortify scan detects issues
+  //ignoreExitValue = true
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2378 (https://tools.hmcts.net/jira/browse/CCD-2378)


### Change description ###
- No change to fortify-client.properties required as fortify release id has not changed.
- Uncommented Fortify scan steps in Jenkinsfile_nightly to re-enable Fortify scan


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
