### PR TITLE
CVE fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,11 +203,11 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
-  netty           : '4.1.68.Final'
+  netty           : '4.1.74.Final'
 ]
 
-ext['spring-framework.version'] = '5.3.12'
-ext['log4j2.version'] = '2.17.0'
+ext['spring-framework.version'] = '5.3.15'
+ext['log4j2.version'] = '2.17.1'
 
 // before committing a change, make sure task still works
 dependencyUpdates {
@@ -237,7 +237,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.54') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.58') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'
@@ -291,6 +291,9 @@ dependencies {
 
   // Explicitly specify version of jakarta.el to be used to resolve CVE-2021-28170
   implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'
+  // CVE-2021-42550
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.10'
 
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
@@ -317,7 +320,7 @@ dependencies {
   implementation group: 'org.eclipse.jetty', name: 'jetty-alpn-conscrypt-server', version: versions.jetty
   implementation group: 'org.eclipse.jetty', name: 'jetty-alpn-conscrypt-client', version: versions.jetty
 
-  // Explicitly set versions of io.netty components to resolve CVE-2021-37136 and CVE-2021-37137
+  // CVE-2021-43797, CVE-2021-21290
   implementation group: 'io.netty', name: 'netty-buffer', version: versions.netty
   implementation group: 'io.netty', name: 'netty-codec', version: versions.netty
   implementation group: 'io.netty', name: 'netty-codec-dns', version: versions.netty

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.4.5'
-  id 'org.owasp.dependencycheck' version '6.1.5'
+  id 'org.owasp.dependencycheck' version '6.5.3'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.1.1'
   id 'uk.gov.hmcts.java' version '0.12.2'
@@ -207,6 +207,7 @@ def versions = [
 ]
 
 ext['spring-framework.version'] = '5.3.15'
+ext['spring-security.version'] = '5.4.7'
 ext['log4j2.version'] = '2.17.1'
 
 // before committing a change, make sure task still works
@@ -241,6 +242,12 @@ dependencyManagement {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'
+    }
+    //CVE-2021-22044
+    dependencySet(group: 'org.springframework.cloud', version: '3.0.5') {
+      entry 'spring-cloud-openfeign-core'
+      entry 'spring-cloud-starter-openfeign'
+      entry 'spring-cloud-starter-contract-stub-runner'
     }
   }
 }
@@ -277,7 +284,7 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.0.2'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
@@ -347,7 +354,7 @@ dependencies {
   testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.1'
   testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
 
-  testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner', version: '3.0.2'
+  testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner'
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2022-02-25">
-        <notes>Declared as False Positive
-            https://github.com/jeremylong/DependencyCheck/issues/4065</notes>
-        <cve>CVE-2021-43797</cve>
-    </suppress>
+
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-
     <suppress until="2022-02-25">
-        <notes><![CDATA[Temporary suppression pending investigation]]></notes>
-        <cve>CVE-2021-44832</cve>
-        <cve>CVE-2021-42550</cve>
+        <notes>Declared as False Positive
+            https://github.com/jeremylong/DependencyCheck/issues/4065</notes>
         <cve>CVE-2021-43797</cve>
-        <cve>CVE-2021-22060</cve>
-        <cve>CVE-2022-23181</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-2648
https://tools.hmcts.net/jira/browse/CCD-2644
https://tools.hmcts.net/jira/browse/CCD-2632
https://tools.hmcts.net/jira/browse/CCD-2619
https://tools.hmcts.net/jira/browse/CCD-2593

### Change description ###
Fixing:
- CVE-2021-22060 spring framework upgrade
- CVE-2022-23181 tomcat upgrade
- CVE-2021-42550 ch.qos.logback
- CVE-2021-44832 log4j upgrade
- CVE-2021-43797 netty upgrade
- CVE-2021-22044 spring cloud upgrade
- CVE-2021-22119 spring security upgrade

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```