### PR TITLE
HMAN-171 - Error if hearingVenue.locationReferences.key != to EPIMS

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,6 +12,10 @@
     <cve>CVE-2013-4152</cve>
     <cve>CVE-2014-0054</cve>
     <cve>CVE-2013-7315</cve>
+    <cve>CVE-2022-22968</cve>
+    <cve>CVE-2022-22968</cve>
+    <cve>CVE-2020-11022</cve>
+    <cve>CVE-2020-11023</cve>
   </suppress>
 
   <suppress until="2022-05-25">

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -5,8 +5,6 @@
     <cve>CVE-2013-4152</cve>
     <cve>CVE-2014-0054</cve>
     <cve>CVE-2013-7315</cve>
-    <cve>CVE-2022-22968</cve>
-    <cve>CVE-2022-22968</cve>
     <cve>CVE-2020-11022</cve>
     <cve>CVE-2020-11023</cve>
   </suppress>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HmcInboundControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/hmc/controllers/HmcInboundControllerIT.java
@@ -39,7 +39,6 @@ class HmcInboundControllerIT extends BaseTest {
                .content(objectMapper.writeValueAsString(TestingUtil.getHearingRequestMandatoryFieldMissing())))
             .andExpect(status().is(400))
             .andReturn();
-
     }
 
     @Test
@@ -71,7 +70,17 @@ class HmcInboundControllerIT extends BaseTest {
                 .content(objectMapper.writeValueAsString(TestingUtil.getMetaRequestMandatoryFieldMissing())))
                 .andExpect(status().is(400))
                 .andReturn();
+    }
 
+    @Test
+    void shouldReturn400_when_HearingVenueLocationReferencesKeyEqualsEpims_NotPresent() throws Exception {
+        stubSuccessfullyGetResponseFromCft(listingId);
+        mockMvc.perform(put(url)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(objectMapper.writeValueAsString(
+                        TestingUtil.getHearingVenueLocationReferencesKeyDoesNotEqualsEpims())))
+                .andExpect(status().is(400))
+                .andReturn();
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/hmc/client/model/hmi/Hearing.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/client/model/hmi/Hearing.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.hmc.exceptions.ValidationError;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -64,9 +64,9 @@ public class Hearing {
 
     private String hearingVhGroupId;
 
-    private ArrayList<HearingAttendee> hearingAttendees;
+    private List<HearingAttendee> hearingAttendees;
 
-    private ArrayList<HearingJoh> hearingJohs;
+    private List<HearingJoh> hearingJohs;
 
     private JsonNode hearingSessions;
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/client/model/hmi/HearingVenue.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/client/model/hmi/HearingVenue.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
+import java.util.List;
 import javax.validation.Valid;
 
 @Data
@@ -15,5 +15,5 @@ public class HearingVenue {
     private JsonNode locationRegion;
     private JsonNode locationCluster;
     @Valid
-    private ArrayList<VenueLocationReference> locationReferences;
+    private List<VenueLocationReference> locationReferences;
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/constants/Constants.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/constants/Constants.java
@@ -10,4 +10,5 @@ public final class Constants {
         + "your browser or try again later";
     public static final String INVALID_ERROR_CODE_ERR_MESSAGE = "Error code is invalid";
     public static final String INVALID_HEARING_PAYLOAD = "Invalid json request";
+    public static final String INVALID_LOCATION_REFERENCES = "Location reference EPIMS must be supplied";
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/constants/Constants.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/constants/Constants.java
@@ -10,5 +10,5 @@ public final class Constants {
         + "your browser or try again later";
     public static final String INVALID_ERROR_CODE_ERR_MESSAGE = "Error code is invalid";
     public static final String INVALID_HEARING_PAYLOAD = "Invalid json request";
-    public static final String INVALID_LOCATION_REFERENCES = "Location reference EPIMS must be supplied";
+    public static final String INVALID_LOCATION_REFERENCES = "At least one EPIMS location reference must be supplied";
 }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HmcInboundControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/controllers/HmcInboundControllerTest.java
@@ -88,4 +88,12 @@ class HmcInboundControllerTest {
         verify(hearingManagementService, times(1)).processRequest(any(), any());
     }
 
+    @Test
+    void shouldReturn400_when_HearingVenueLocationReferencesKeyEqualsEpims_NotPresent() {
+        doNothing().when(hearingManagementService).processRequest(Mockito.anyString(),Mockito.any());
+        HmcInboundController controller = new HmcInboundController(hearingManagementService);
+        controller.getResponseFromHmi("123", TestingUtil.getHearingVenueLocationReferencesKeyDoesNotEqualsEpims());
+        verify(hearingManagementService, times(1)).processRequest(any(), any());
+
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/service/HearingManagementServiceImplTest.java
@@ -9,12 +9,14 @@ import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.reform.hmc.ApplicationParams;
 import uk.gov.hmcts.reform.hmc.client.model.hmi.HearingDetailsRequest;
 import uk.gov.hmcts.reform.hmc.config.MessageSenderConfiguration;
+import uk.gov.hmcts.reform.hmc.constants.Constants;
 import uk.gov.hmcts.reform.hmc.exceptions.BadRequestException;
 import uk.gov.hmcts.reform.hmc.service.common.ObjectMapperService;
 import uk.gov.hmcts.reform.hmc.utils.TestingUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -113,4 +115,14 @@ class HearingManagementServiceImplTest {
         verify(cftHearingService, times(1)).isValidCaseId(any());
     }
 
+    @Test
+    void shouldFailAsHearingVenueLocationReferencesKeyEqualsEpimsMissing() {
+        HearingDetailsRequest request = TestingUtil.getHearingVenueLocationReferencesKeyDoesNotEqualsEpims();
+        given(cftHearingService.isValidCaseId(validCaseId)).willReturn(true);
+        when(objectMapperService.convertObjectToJsonNode(request.getHearingResponse())).thenReturn(jsonNode);
+        final BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> hearingManagementService.processRequest(validCaseId, request));
+        assertEquals(Constants.INVALID_LOCATION_REFERENCES, badRequestException.getMessage());
+        verify(cftHearingService, times(1)).isValidCaseId(any());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/hmc/utils/TestingUtil.java
@@ -7,10 +7,13 @@ import uk.gov.hmcts.reform.hmc.client.model.hmi.HearingCode;
 import uk.gov.hmcts.reform.hmc.client.model.hmi.HearingDetailsRequest;
 import uk.gov.hmcts.reform.hmc.client.model.hmi.HearingResponse;
 import uk.gov.hmcts.reform.hmc.client.model.hmi.HearingStatus;
+import uk.gov.hmcts.reform.hmc.client.model.hmi.HearingVenue;
 import uk.gov.hmcts.reform.hmc.client.model.hmi.ListingStatus;
 import uk.gov.hmcts.reform.hmc.client.model.hmi.MetaResponse;
+import uk.gov.hmcts.reform.hmc.client.model.hmi.VenueLocationReference;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public  class TestingUtil {
 
@@ -92,6 +95,7 @@ public  class TestingUtil {
         hearing.setHearingTranslatorRequired(false);
         hearing.setHearingCreatedDate(LocalDateTime.now());
         hearing.setHearingCreatedBy("sysadm");
+        hearing.setHearingVenue(getHearingVenue("EPIMS"));
         hearingResponse.setHearing(hearing);
 
         HearingDetailsRequest request = new HearingDetailsRequest();
@@ -128,6 +132,28 @@ public  class TestingUtil {
         HearingDetailsRequest request = new HearingDetailsRequest();
         request.setHearingResponse(hearingResponse);
         return request;
+    }
+
+    public static HearingDetailsRequest getHearingVenueLocationReferencesKeyDoesNotEqualsEpims() {
+        final HearingDetailsRequest hearingDetailsRequest = getHearingRequest();
+        final HearingResponse hearingResponse = hearingDetailsRequest.getHearingResponse();
+        final Hearing hearing = hearingResponse.getHearing();
+        hearing.setHearingVenue(getHearingVenue("notEPIMSKey"));
+
+        hearingResponse.setHearing(hearing);
+        hearingDetailsRequest.setHearingResponse(hearingResponse);
+
+        return hearingDetailsRequest;
+
+    }
+
+    private static HearingVenue getHearingVenue(String key) {
+        VenueLocationReference venueLocationReference = new VenueLocationReference();
+        venueLocationReference.setKey(key);
+
+        HearingVenue hearingVenue = new HearingVenue();
+        hearingVenue.setLocationReferences(List.of(venueLocationReference));
+        return hearingVenue;
     }
 
     public static HearingDetailsRequest getMetaRequestMandatoryFieldMissing() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-171

### Change description ###

**Problem:** If ListAssist do not populate the hearing response with a hearingVenue.locationReferences.key = EPIMS then by our spec we don't populate any value in the database for hearingDayDetails.venueId. This however gives a db error

**Solution:** If the locationReferences array does NOT contain a key - "EPIMS" , then throw a validation error with appropriate message such as "Location reference EPIMS must be supplied". 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
