### PR TITLE
CCD-3121: CVE-2022-22968: hmc-hmi-inbound-adaptor fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ def versions = [
   netty           : '4.1.74.Final'
 ]
 
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 ext['spring-security.version'] = '5.6.2'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,6 +8,7 @@
       <cve>CVE-2020-36518</cve>
     </suppress>
     <suppress until="2022-05-25">
+        <cve>CVE-2022-22968</cve>
         <cve>CVE-2022-22965</cve>
         <cve>CVE-2016-1000027</cve>
         <cve>CVE-2014-0054</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,7 +8,6 @@
       <cve>CVE-2020-36518</cve>
     </suppress>
     <suppress until="2022-05-25">
-        <cve>CVE-2022-22968</cve>
         <cve>CVE-2022-22965</cve>
         <cve>CVE-2016-1000027</cve>
         <cve>CVE-2014-0054</cve>
@@ -48,126 +47,6 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-metadata@.*$</packageUrl>
     <cve>CVE-2022-22965</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-aop-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-aspects-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aspects@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-beans-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-context-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-context-support-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context\-support@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-core-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-expression-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-jcl-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jcl@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-jdbc-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jdbc@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-orm-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-orm@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-plugin-core-2.0.0.RELEASE.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-core@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-plugin-metadata-2.0.0.RELEASE.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework\.plugin/spring\-plugin\-metadata@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-tx-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-tx@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-web-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
-  <suppress until="2022-05-25">
-    <notes><![CDATA[
-   file name: spring-webmvc-5.3.18.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
-    <cve>CVE-2022-22968</cve>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3121

### Change description ###

Upgrading framework to 5.3.19 due to this vulnerability:
In Spring Framework versions 5.3.0 - 5.3.18, 5.2.0 - 5.2.20, and older unsupported versions, the patterns for disallowedFields on a DataBinder are case sensitive which means a field is not effectively protected unless it is listed with both upper and lower case for the first character of the field, including upper and lower case for the first character of all nested fields within the property path.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
