### PR TITLE
CVE-2013-7315: hmc-hmi-inbound-adaptor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ def versions = [
   netty           : '4.1.74.Final'
 ]
 
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 ext['spring-security.version'] = '5.6.2'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'

--- a/charts/hmc-hmi-inbound-adapter/Chart.yaml
+++ b/charts/hmc-hmi-inbound-adapter/Chart.yaml
@@ -3,14 +3,14 @@ appVersion: "1.0"
 description: A Helm chart for hmc-hmi-inbound-adapter App
 name: hmc-hmi-inbound-adapter
 home: https://github.com/hmcts/hmc-hmi-inbound-adapter
-version: 0.1.5
+version: 0.1.6
 maintainers:
   - name: HMCTS CCD Dev Team
 dependencies:
   - name: java
     version: 3.7.3
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
     version: 0.3.0
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: servicebus.enabled

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -13,7 +13,6 @@
         <cve>CVE-2016-1000027</cve>
         <cve>CVE-2014-0054</cve>
         <cve>CVE-2013-4152</cve>
-        <cve>CVE-2013-7315</cve>
         <cve>CVE-2020-11022</cve>
         <cve>CVE-2020-11023</cve>
     </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3118

### Change description ###

Upgrading framework to 5.3.19 due to this vulnerability:
In Spring Framework versions 5.3.0 - 5.3.18, 5.2.0 - 5.2.20, and older unsupported versions, the patterns for disallowedFields on a DataBinder are case sensitive which means a field is not effectively protected unless it is listed with both upper and lower case for the first character of the field, including upper and lower case for the first character of all nested fields within the property path.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
