### PR TITLE
CVE-2020-11023 fix

### DIFF
--- a/charts/hmc-hmi-inbound-adapter/Chart.yaml
+++ b/charts/hmc-hmi-inbound-adapter/Chart.yaml
@@ -3,14 +3,14 @@ appVersion: "1.0"
 description: A Helm chart for hmc-hmi-inbound-adapter App
 name: hmc-hmi-inbound-adapter
 home: https://github.com/hmcts/hmc-hmi-inbound-adapter
-version: 0.1.5
+version: 0.1.6
 maintainers:
   - name: HMCTS CCD Dev Team
 dependencies:
   - name: java
     version: 3.7.3
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: servicebus
     version: 0.3.0
-    repository: '@hmctspublic'
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: servicebus.enabled

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,7 +14,6 @@
         <cve>CVE-2014-0054</cve>
         <cve>CVE-2013-4152</cve>
         <cve>CVE-2013-7315</cve>
-        <cve>CVE-2020-11022</cve>
     </suppress>
 
   <suppress until="2022-05-25">

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,7 +15,6 @@
         <cve>CVE-2013-4152</cve>
         <cve>CVE-2013-7315</cve>
         <cve>CVE-2020-11022</cve>
-        <cve>CVE-2020-11023</cve>
     </suppress>
 
   <suppress until="2022-05-25">


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3120

### Change description ###

In jQuery versions greater than or equal to 1.0.3 and before 3.5.0, passing HTML containing <option> elements from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code. This problem is patched in jQuery 3.5.0.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
