### PR TITLE
Updated wiremock to 2.33.2, remove suppression CVE-2020-11022

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,7 +297,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.serviceAuth
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
 
-  implementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.33.2'
+ //group: 'com.github.tomakehurst', name: 'wiremock', version: '2.33.2'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: "com.github.ben-manes.caffeine", name: "caffeine", version: "3.0.6"
@@ -363,6 +363,8 @@ dependencies {
 
   testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.1'
   testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
+
+  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:2.33.2"
 
   testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner'
   integrationTestImplementation sourceSets.main.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -297,7 +297,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.serviceAuth
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
 
-  implementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.2'
+  implementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.33.2'
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: "com.github.ben-manes.caffeine", name: "caffeine", version: "3.0.6"

--- a/build.gradle
+++ b/build.gradle
@@ -296,7 +296,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.serviceAuth
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
-  
+
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: "com.github.ben-manes.caffeine", name: "caffeine", version: "3.0.6"

--- a/build.gradle
+++ b/build.gradle
@@ -296,8 +296,7 @@ dependencies {
 
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.serviceAuth
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
-
- //group: 'com.github.tomakehurst', name: 'wiremock', version: '2.33.2'
+  
   implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.0.2'
   implementation group: 'com.azure', name: 'azure-core', version: '1.13.0'
   implementation group: "com.github.ben-manes.caffeine", name: "caffeine", version: "3.0.6"
@@ -364,7 +363,7 @@ dependencies {
   testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.1'
   testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
 
-  testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:2.33.2"
+  testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.27.2'
 
   testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner'
   integrationTestImplementation sourceSets.main.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,7 +14,6 @@
         <cve>CVE-2014-0054</cve>
         <cve>CVE-2013-4152</cve>
         <cve>CVE-2013-7315</cve>
-        <cve>CVE-2020-11023</cve>
     </suppress>
 
   <suppress until="2022-05-25">

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,7 +14,6 @@
         <cve>CVE-2014-0054</cve>
         <cve>CVE-2013-4152</cve>
         <cve>CVE-2013-7315</cve>
-        <cve>CVE-2020-11022</cve>
         <cve>CVE-2020-11023</cve>
     </suppress>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3119

### Change description ###

Updated wiremock to 2.33.2, remove suppression CVE-2020-11022

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
