### PR TITLE
CVE-2022-24823 : hmc-hmi-inbound-adapter fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
-  netty           : '4.1.77'
+  netty           : '4.1.77.Final'
 ]
 
 ext['spring-framework.version'] = '5.3.19'

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
-  netty           : '4.1.74.Final'
+  netty           : '4.1.77'
 ]
 
 ext['spring-framework.version'] = '5.3.19'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -50,11 +50,4 @@
     <cve>CVE-2022-22965</cve>
   </suppress>
 
-  <suppress until="2022-06-25">
-    <notes><![CDATA[
-      file name: netty-codec-***-4.1.74.Final.jar
-   ]]></notes>
-    <cve>CVE-2022-24823</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3187

Upgrading netty version to 4.1.77.
Netty is an open-source, asynchronous event-driven network application framework. The package `io.netty:netty-codec-http` prior to version 4.1.77.Final contains an insufficient fix for CVE-2021-21290.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
