### PR TITLE
Ccd 3262 fortify docker uses root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN java -Djarmode=layertools -jar application.jar extract
 
 ARG APP_INSIGHTS_AGENT_VERSION=2.5.1
 FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.4
+USER hmcts
 
 COPY lib/AI-Agent.xml /opt/app/
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3262
Fortify Issue 24255736 - Dockerfile Misconfiguration: Default User Privilege - High
root Dockerfile

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
