### PR TITLE
HMAN-330 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.65') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -77,20 +77,15 @@
   </suppress>
 
   <suppress>
-    <notes>https://tools.hmcts.net/jira/browse/HMAN-327</notes>
-    <cve>CVE-2022-34305</cve>
-  </suppress>
-
-  <suppress>
     <notes></notes>
     <cve>CVE-2022-33915</cve>
   </suppress>
-  
+
   <suppress>
     <cve>CVE-2022-2047</cve>
     <cve>CVE-2022-2048</cve>
   </suppress>
-  
+
   <suppress>
     <notes>https://tools.hmcts.net/jira/browse/HMAN-416</notes>
     <cve>CVE-2022-25857</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/HMAN-330
CVE-2022-34305 tomcat upgrade 9.0.65

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
