### PR TITLE
HMAN-423, HMAN-433, HMAN--439 CVE suppressions.

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -85,22 +85,38 @@
     <notes></notes>
     <cve>CVE-2022-33915</cve>
   </suppress>
-  
+
   <suppress>
     <cve>CVE-2022-2047</cve>
     <cve>CVE-2022-2048</cve>
   </suppress>
-  
+
   <suppress>
     <notes>https://tools.hmcts.net/jira/browse/HMAN-416</notes>
     <cve>CVE-2022-25857</cve>
   </suppress>
-  
+
   <suppress>
     <notes></notes>
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
+  </suppress>
+  <suppress>
+    <notes>Temporary Suppression
+      CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
+      CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
+      CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
+      CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-433
+      CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
+      CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
+    </notes>
+    <cve>CVE-2022-38751</cve>
+    <cve>CVE-2022-38750</cve>
+    <cve>CVE-2022-38749</cve>
+    <cve>CVE-2022-38752</cve>
+    <cve>CVE-2022-42003</cve>
+    <cve>CVE-2022-42004</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Suppression of CVE's
CVE-2022-38751
CVE-2022-38750
CVE-2022-38749
CVE-2022-38752
CVE-2022-42003
CVE-2022-42004


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-423
https://tools.hmcts.net/jira/browse/HMAN-433
https://tools.hmcts.net/jira/browse/HMAN-439


### Change description ###

CVE-2022-38751 CVE-2022-38750 CVE-2022-38749 hmc repos
CVE-2022-38752 - hmc-hmi-inbound-adapter
CVE-2022-42003 and CVE-2022-42004 - hmc-hmi-inbound-adapter

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
