### PR TITLE
HMAN-433 fix for CVE-2022-38752 - update snakeyaml to version 1.32

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,8 @@ def versions = [
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
   netty           : '4.1.77.Final' ,
-  snakeyaml       : '1.32'
+  snakeyaml       : '1.32' ,
+  jackson         : '2.14.0-rc1'
 ]
 
 ext['spring-framework.version'] = '5.3.21'
@@ -280,7 +281,7 @@ ext.libraries = [
 ]
 
 dependencies {
-  compile "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
+  compile "com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1"
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,8 @@ def versions = [
   springfoxSwagger: '3.0.0',
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
-  netty           : '4.1.77.Final'
+  netty           : '4.1.77.Final' ,
+  snakeyaml       : '1.32'
 ]
 
 ext['spring-framework.version'] = '5.3.21'
@@ -356,6 +357,7 @@ dependencies {
   implementation group: 'io.netty', name: 'netty-transport-native-epoll', version: versions.netty
   implementation group: 'io.netty', name: 'netty-transport-native-kqueue', version: versions.netty
   implementation group: 'io.netty', name: 'netty-transport-native-unix-common', version: versions.netty
+  implementation group: 'org.yaml', name: 'snakeyaml', version: versions.snakeyaml
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {

--- a/build.gradle
+++ b/build.gradle
@@ -205,8 +205,7 @@ def versions = [
   testcontainers  : '1.15.2',
   jetty           : '9.4.43.v20210629',
   netty           : '4.1.77.Final' ,
-  snakeyaml       : '1.32' ,
-  jackson         : '2.14.0-rc1'
+  snakeyaml       : '1.32'
 ]
 
 ext['spring-framework.version'] = '5.3.21'
@@ -281,7 +280,7 @@ ext.libraries = [
 ]
 
 dependencies {
-  compile "com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1"
+  compile "com.fasterxml.jackson.core:jackson-databind:2.13.2.2"
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -108,13 +108,9 @@
       CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
-      CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
-    <cve>CVE-2022-42003</cve>
-    <cve>CVE-2022-42004</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -108,14 +108,12 @@
       CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-433
       CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
-    <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -108,9 +108,13 @@
       CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
+      CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
+      CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
     <cve>CVE-2022-38749</cve>
+    <cve>CVE-2022-42003</cve>
+    <cve>CVE-2022-42004</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -105,15 +105,9 @@
   </suppress>
   <suppress>
     <notes>Temporary Suppression
-      CVE-2022-38751 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38750 refer https://tools.hmcts.net/jira/browse/HMAN-423
-      CVE-2022-38749 refer https://tools.hmcts.net/jira/browse/HMAN-423
       CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
     </notes>
-    <cve>CVE-2022-38751</cve>
-    <cve>CVE-2022-38750</cve>
-    <cve>CVE-2022-38749</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
   </suppress>


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-433
https://tools.hmcts.net/jira/browse/HMAN-423


### Change description ###
HMAN-433 - fix CVE-2022-38752  - updated snakeyaml to version 1.32
HMAN-423 - fix CVE-2022-38751 CVE-2022-38750 CVE-2022-38749 -  - updated snakeyaml to version 1.32


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
