### PR TITLE
HMAN-455,HMAN-454: Tomcat and Spring Security 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,7 +208,7 @@ def versions = [
 ]
 
 ext['spring-framework.version'] = '5.3.21'
-ext['spring-security.version'] = '5.7.2'
+ext['spring-security.version'] = '5.7.5'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -240,7 +240,7 @@ dependencyManagement {
       entry 'json-path'
       entry 'xml-path'
     }
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,7 @@ ext['spring-framework.version'] = '5.3.21'
 ext['spring-security.version'] = '5.7.5'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
+ext['snakeyaml.version'] = '1.33'
 
 // before committing a change, make sure task still works
 dependencyUpdates {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -113,7 +113,6 @@
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
       CVE-2022-31690 refer https://tools.hmcts.net/jira/browse/HMAN-454
       CVE-2022-31692 refer https://tools.hmcts.net/jira/browse/HMAN-454
-      CVE-2022-42252 refer https://tools.hmcts.net/jira/browse/HMAN-455
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
@@ -123,6 +122,5 @@
     <cve>CVE-2022-42004</cve>
     <cve>CVE-2022-31690</cve>
     <cve>CVE-2022-31692</cve>
-    <cve>CVE-2022-42252</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -111,7 +111,6 @@
       CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-433
       CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
-      CVE-2022-41854 refer https://tools.hmcts.net/jira/browse/HMAN-476
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
@@ -119,6 +118,5 @@
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
-    <cve>CVE-2022-41854</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -111,8 +111,6 @@
       CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-433
       CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
-      CVE-2022-31690 refer https://tools.hmcts.net/jira/browse/HMAN-454
-      CVE-2022-31692 refer https://tools.hmcts.net/jira/browse/HMAN-454
     </notes>
     <cve>CVE-2022-38751</cve>
     <cve>CVE-2022-38750</cve>
@@ -120,7 +118,5 @@
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
-    <cve>CVE-2022-31690</cve>
-    <cve>CVE-2022-31692</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -111,9 +111,6 @@
       CVE-2022-38752 refer https://tools.hmcts.net/jira/browse/HMAN-433
       CVE-2022-42003 refer https://tools.hmcts.net/jira/browse/HMAN-439
       CVE-2022-42004 refer https://tools.hmcts.net/jira/browse/HMAN-439
-      CVE-2022-31690 refer https://tools.hmcts.net/jira/browse/HMAN-454
-      CVE-2022-31692 refer https://tools.hmcts.net/jira/browse/HMAN-454
-      CVE-2022-42252 refer https://tools.hmcts.net/jira/browse/HMAN-455
       CVE-2022-41854 refer https://tools.hmcts.net/jira/browse/HMAN-476
     </notes>
     <cve>CVE-2022-38751</cve>
@@ -122,9 +119,6 @@
     <cve>CVE-2022-38752</cve>
     <cve>CVE-2022-42003</cve>
     <cve>CVE-2022-42004</cve>
-    <cve>CVE-2022-31690</cve>
-    <cve>CVE-2022-31692</cve>
-    <cve>CVE-2022-42252</cve>
     <cve>CVE-2022-41854</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.hmc.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -39,24 +37,27 @@ public class SecurityConfiguration {
     }
 
     @Bean
+    protected SecurityFilterChain allowedList(HttpSecurity http) throws Exception {
+        return http
+            .requestMatchers().antMatchers(AUTH_ALLOWED_LIST)
+            .and()
+            .sessionManagement().sessionCreationPolicy(STATELESS)
+            .and()
+            .authorizeRequests().anyRequest().permitAll()
+            .and()
+            .build();
+    }
+
+    @Bean
     protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
+        return http
             .addFilterBefore(serviceAuthFilter, AbstractPreAuthenticatedProcessingFilter.class)
             .sessionManagement().sessionCreationPolicy(STATELESS)
             .and()
             .httpBasic().disable()
             .formLogin().disable()
             .logout().disable()
-            .csrf().disable();
-        return http.build();
-    }
-
-    @Bean
-    @Order(0)
-    protected SecurityFilterChain allowedList(HttpSecurity http) throws Exception {
-        http
-            .authorizeHttpRequests(authorize -> authorize
-                .antMatchers(HttpMethod.GET, AUTH_ALLOWED_LIST).permitAll());
-        return http.build();
+            .csrf().disable()
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter;
@@ -36,6 +37,10 @@ public class SecurityConfiguration {
         this.serviceAuthFilter = serviceAuthFilter;
     }
 
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().antMatchers(AUTH_ALLOWED_LIST);
+    }
 
     @Bean
     protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.reform.hmc.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter;
 
@@ -13,7 +13,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+public class SecurityConfiguration {
 
     private static final String[] AUTH_ALLOWED_LIST = {
         "/swagger-resources/**",
@@ -36,13 +36,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         this.serviceAuthFilter = serviceAuthFilter;
     }
 
-    @Override
-    public void configure(WebSecurity web) {
-        web.ignoring().mvcMatchers(AUTH_ALLOWED_LIST);
-    }
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .addFilterBefore(serviceAuthFilter, AbstractPreAuthenticatedProcessingFilter.class)
             .sessionManagement().sessionCreationPolicy(STATELESS)
@@ -50,6 +46,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .httpBasic().disable()
             .formLogin().disable()
             .logout().disable()
-            .csrf().disable();
+            .csrf().disable()
+            .authorizeRequests()
+            .antMatchers(AUTH_ALLOWED_LIST).permitAll();
+        return http.build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
@@ -51,9 +51,7 @@ public class SecurityConfiguration {
             .httpBasic().disable()
             .formLogin().disable()
             .logout().disable()
-            .csrf().disable()
-            .authorizeRequests()
-            .antMatchers(AUTH_ALLOWED_LIST).permitAll();
+            .csrf().disable();
         return http.build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -55,12 +56,7 @@ public class SecurityConfiguration {
     protected SecurityFilterChain allowedList(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(authorize -> authorize
-                .antMatchers(AUTH_ALLOWED_LIST).permitAll()
-                .anyRequest().permitAll()
-            )
-            .requestCache().disable()
-            .securityContext().disable()
-            .sessionManagement().disable();
+                .antMatchers(HttpMethod.GET, AUTH_ALLOWED_LIST).permitAll());
         return http.build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/config/SecurityConfiguration.java
@@ -3,9 +3,9 @@ package uk.gov.hmcts.reform.hmc.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import uk.gov.hmcts.reform.authorisation.filters.ServiceAuthFilter;
@@ -38,11 +38,6 @@ public class SecurityConfiguration {
     }
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().antMatchers(AUTH_ALLOWED_LIST);
-    }
-
-    @Bean
     protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
             .addFilterBefore(serviceAuthFilter, AbstractPreAuthenticatedProcessingFilter.class)
@@ -52,6 +47,20 @@ public class SecurityConfiguration {
             .formLogin().disable()
             .logout().disable()
             .csrf().disable();
+        return http.build();
+    }
+
+    @Bean
+    @Order(0)
+    protected SecurityFilterChain allowedList(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorize -> authorize
+                .antMatchers(AUTH_ALLOWED_LIST).permitAll()
+                .anyRequest().permitAll()
+            )
+            .requestCache().disable()
+            .securityContext().disable()
+            .sessionManagement().disable();
         return http.build();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-455
https://tools.hmcts.net/jira/browse/HMAN-454

### Change description ###
Fix for snakeyaml - CVE-2022-41854
Fix for Tomcat - CVE-2022-42252
Fix for  Spring Security - CVE-2022-31690, CVE-2022-31692
- Removed deprecated WebSecurityConfigurerAdapter in [SecurityConfiguration.java](https://github.com/hmcts/hmc-hmi-inbound-adapter/pull/113/files#diff-69a193a5467808675c35026ebbf06bfb8727dd2476f406110a5056356fd8483a)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```