### PR TITLE
HMAN-524 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ def versions = [
   jetty           : '9.4.49.v20220914',
   netty           : '4.1.86.Final' ,
   snakeyaml       : '1.33' ,
-  tomcatEmbedded  : '9.0.69'
+  tomcatEmbedded  : '9.0.73'
 ]
 
 ext['spring-framework.version'] = '5.3.24'
@@ -321,6 +321,7 @@ dependencies {
   implementation "org.apache.tomcat.embed:tomcat-embed-el:${versions.tomcatEmbedded}"
   implementation "org.apache.tomcat.embed:tomcat-embed-websocket:${versions.tomcatEmbedded}"
 
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
 
   implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer [Ticket]
-        CVE-2023-24998 refer [Ticket]</notes>
+        CVE-2022-45688 refer [Ticket]</notes>
     <cve>CVE-2022-45688</cve>
-    <cve>CVE-2023-24998</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/HMAN-524


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
