### PR TITLE
HMAN-576 Fix CVE-2023-34035. Upgrade spring-security 5.8.3 to 5.8.7.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ def versions = [
 ]
 
 ext['spring-framework.version'] = '5.3.27'
-ext['spring-security.version'] = '5.8.3'
+ext['spring-security.version'] = '5.8.7'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '1.33'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,7 +16,10 @@
         CVE-2023-36479 refer [Ticket]
         CVE-2023-41900 refer [Ticket]
         CVE-2023-40167 refer [Ticket]
-        CVE-2023-4586 refer [Ticket]</notes>
+        CVE-2023-4586 refer [Ticket]
+        CVE-2023-42794 refer [Ticket]
+        CVE-2023-42795 refer [Ticket]
+        CVE-2023-45648 refer [Ticket]</notes>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-20873</cve>
     <cve>CVE-2023-28709</cve>
@@ -30,5 +33,8 @@
     <cve>CVE-2023-41900</cve>
     <cve>CVE-2023-40167</cve>
     <cve>CVE-2023-4586</cve>
+    <cve>CVE-2023-42794</cve>
+    <cve>CVE-2023-42795</cve>
+    <cve>CVE-2023-45648</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,7 +19,8 @@
         CVE-2023-4586 refer [Ticket]
         CVE-2023-42794 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]</notes>
+        CVE-2023-45648 refer [Ticket]
+        CVE-2023-44487 refer [Ticket]</notes>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-20873</cve>
     <cve>CVE-2023-28709</cve>
@@ -36,5 +37,6 @@
     <cve>CVE-2023-42794</cve>
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
+    <cve>CVE-2023-44487</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,8 @@
         CVE-2023-42794 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]</notes>
+        CVE-2023-44487 refer [Ticket]
+        CVE-2023-36478 refer [Ticket]</notes>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-20873</cve>
     <cve>CVE-2023-28709</cve>
@@ -38,5 +39,6 @@
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
     <cve>CVE-2023-44487</cve>
+    <cve>CVE-2023-36478</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,9 +7,8 @@
         CVE-2023-28709 refer [Ticket]
         CVE-2023-20883 refer [Ticket]
         CVE-2023-35116 refer [Ticket]
-    
+
         CVE-2023-34462 refer [Ticket]
-        CVE-2023-34035 refer [Ticket]
         CVE-2023-34034 refer [Ticket]
         CVE-2023-34040 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
@@ -28,7 +27,6 @@
     <cve>CVE-2023-20883</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-34462</cve>
-    <cve>CVE-2023-34035</cve>
     <cve>CVE-2023-34034</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-36479</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMAN-576

### Change description ###

Fix CVE-2023-34035 in all HMC repos

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
