### PR TITLE
HMAN-1152: Resolve CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -277,8 +277,8 @@ dependencies {
 
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
   implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.6.0'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.26.0'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.26.0'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.26.1'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.26.1'
   implementation platform('tools.jackson:jackson-bom:3.2.0')
 
   // end::CVE Vulnerability dependency overrides                                                            // MAIN PARENT DEPENDEDNCY

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.owasp.dependencycheck' version '12.2.2'
   id 'org.sonarqube' version '6.3.1.5724'
-  id 'org.springframework.boot' version '3.5.14'
+  id 'org.springframework.boot' version '3.5.16'
   id 'uk.gov.hmcts.java' version '0.12.70'
 }
 
@@ -193,16 +193,12 @@ sonarqube {
 
 ext {
   set('springCloudVersion', '2025.0.1')
-  set('spring-framework.version', '6.2.18')
-  set('spring-security.version', '6.5.10')
-  set('netty.version', '4.2.14.Final')
-  set('tomcat.version', '10.1.55')
-  set('jackson.version', '2.18.2')
+  set('tomcat.version', '10.1.56')
+  set('jackson.version', '2.18.9')
   set('snakeyaml.version', '2.3')
   logback         = '1.5.29'
   lombok          = '1.18.42'
   mapstruct       = '1.6.3'
-  tomcatEmbedded  = '10.1.55'
   // test versions
   junit           = '6.0.2'
   junitPlatform   = '6.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ sonarqube {
 
 ext {
   set('springCloudVersion', '2025.0.1')
-  set('tomcat.version', '10.1.56')
+  set('tomcat.version', '10.1.57')
   set('jackson.version', '2.18.9')
   set('snakeyaml.version', '2.3')
   logback         = '1.5.29'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -10,12 +10,6 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-        Temporary Suppression for CVEs reported in dependency-check-report-master-hmc-hmi-inbound.html.
-        ]]></notes>
-        <cve>CVE-2026-33117</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
         file name: angus-activation-2.0.3.jar
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,6 +11,7 @@
     <suppress>
         <notes><![CDATA[
         file name: angus-activation-2.0.3.jar
+        Believed to be a false positive, see https://github.com/dependency-check/DependencyCheck/issues/8130
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>
         <cve>CVE-2025-7962</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,64 +14,6 @@
         ]]></notes>
         <cve>CVE-2023-44487</cve>
         <cve>CVE-2026-33117</cve>
-        <cve>CVE-2026-40988</cve>
-        <cve>CVE-2026-41003</cve>
-        <cve>CVE-2026-41694</cve>
-        <cve>CVE-2026-41706</cve>
-        <cve>CVE-2026-41838</cve>
-        <cve>CVE-2026-41844</cve>
-        <cve>CVE-2026-41845</cve>
-        <cve>CVE-2026-41846</cve>
-        <cve>CVE-2026-41848</cve>
-        <cve>CVE-2026-41852</cve>
-        <cve>CVE-2026-41853</cve>
-        <cve>CVE-2026-41854</cve>
-        <cve>CVE-2026-41855</cve>
-        <cve>CVE-2026-44249</cve>
-        <cve>CVE-2026-44250</cve>
-        <cve>CVE-2026-44890</cve>
-        <cve>CVE-2026-44892</cve>
-        <cve>CVE-2026-44893</cve>
-        <cve>CVE-2026-44894</cve>
-        <cve>CVE-2026-45416</cve>
-        <cve>CVE-2026-45536</cve>
-        <cve>CVE-2026-45673</cve>
-        <cve>CVE-2026-45674</cve>
-        <cve>CVE-2026-46340</cve>
-        <cve>CVE-2026-47244</cve>
-        <cve>CVE-2026-47691</cve>
-        <cve>CVE-2026-47838</cve>
-        <cve>CVE-2026-48006</cve>
-        <cve>CVE-2026-48043</cve>
-        <cve>CVE-2026-48059</cve>
-        <cve>CVE-2026-48748</cve>
-        <cve>CVE-2026-50009</cve>
-        <cve>CVE-2026-50010</cve>
-        <cve>CVE-2026-50011</cve>
-        <cve>CVE-2026-50020</cve>
-        <cve>CVE-2026-50560</cve>
-        <cve>CVE-2026-54512</cve>
-        <cve>CVE-2026-54513</cve>
-        <cve>CVE-2026-54514</cve>
-        <cve>CVE-2026-54515</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2026-41842</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2026-41850</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2026-41851</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2026-41840</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2026-41841</cve>
-    </suppress>
-    <suppress>
-        <cve>CVE-2026-41843</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -79,19 +21,6 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.eclipse\.angus/angus-activation@.*$</packageUrl>
         <cve>CVE-2025-7962</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-        Temporary suppression for CVEs reported in hmc-inbound-dependency-check-report.html.
-        file names: tomcat-embed-core-10.1.55.jar, tomcat-embed-websocket-10.1.55.jar
-        ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/(tomcat-embed-core|tomcat-embed-websocket)@10\.1\.55$</packageUrl>
-        <cve>CVE-2026-50229</cve>
-        <cve>CVE-2026-53404</cve>
-        <cve>CVE-2026-53434</cve>
-        <cve>CVE-2026-55276</cve>
-        <cve>CVE-2026-55955</cve>
-        <cve>CVE-2026-55956</cve>
     </suppress>
     <suppress>
       <cve>CVE-2026-54399</cve>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,9 +17,16 @@
         <cve>CVE-2025-7962</cve>
     </suppress>
     <suppress>
-      <cve>CVE-2026-54399</cve>
-    </suppress>
-    <suppress>
-      <cve>CVE-2026-54428</cve>
+        <notes><![CDATA[
+        The cve.org records for these CVEs indicate that they only apply to httpcore 5.x, but the NVD records state
+        that they apply to all versions up to and including 5.4.2.
+        Discussion at https://github.com/dependency-check/DependencyCheck/issues/8653 suggests NVD need to update their
+        records to exclude versions before 5.x, but there is a suggestion that it could also affect 4.4.16.
+        Apache httpcore 4 is EOL (https://hc.apache.org/httpcomponents-core-4.4.x/index.html) so there may not be any
+        more releases of it.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore@4\.4\.16$</packageUrl>
+        <cve>CVE-2026-54399</cve>
+        <cve>CVE-2026-54428</cve>
     </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,7 +12,6 @@
         <notes><![CDATA[
         Temporary Suppression for CVEs reported in dependency-check-report-master-hmc-hmi-inbound.html.
         ]]></notes>
-        <cve>CVE-2023-44487</cve>
         <cve>CVE-2026-33117</cve>
     </suppress>
     <suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###
[HMAN-1152](https://tools.hmcts.net/jira/browse/HMAN-1152)


### Change description ###
Updated Spring Boot version to 3.5.16.

Removed spring-framework.version, spring-security.version and netty.version properties so that default versions provided by Spring Boot 3.5.16 will be used.

Updated tomcat.version property to 10.1.57

Updated jackson.version property to 2.18.9.  Unable to use 2.21.x provided by Spring Boot due to limitation caused by befta-fw.

Removed tomcatEmbedded property as it is no longer used.  It was used to set the version of three explicit tomcat-embed dependencies, but these were removed in pull request #209.

Updated log4j version to 2.26.1

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
